### PR TITLE
Alias committed stock to fetch the correct value from endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.8 (2015-04-28)
+- Fetch VariantLocation#committed_stock as committed
+
 ## 0.0.7 (2015-03-17)
 - Fix issue with Order#tax_override
 - Support sideloaded records without a hack

--- a/lib/gecko/record/variant.rb
+++ b/lib/gecko/record/variant.rb
@@ -7,9 +7,11 @@ module Gecko
         include Virtus.model
         include Gecko::Helpers::SerializationHelper
         attribute :location_id,     Integer
-        attribute :committed_stock, BigDecimal
+        attribute :committed,       BigDecimal
         attribute :stock_on_hand,   BigDecimal
         attribute :bin_location,    String
+
+        alias_method :committed_stock, :committed
       end
 
       class VariantPrice

--- a/test/record/variant_test.rb
+++ b/test/record/variant_test.rb
@@ -32,8 +32,10 @@ class Gecko::VariantTest < Minitest::Test
 
   def test_variant_locations
     json = {locations: [
-      {location_id: 1, stock_on_hand: "12.50", committed_stock: "0", bin_location: "AB-123"},
+      { location_id: 1, stock_on_hand: "12.50",
+        committed: "0", bin_location: "AB-123" },
     ]}
+
     locations = record_class.new(client, json).locations
     assert_instance_of(Gecko::Record::Variant::VariantLocation, locations.first)
     assert_equal(1,        locations[0].location_id)


### PR DESCRIPTION
Since the API endpoint returns `committed` as the key in the variant location, the Gecko gem is not getting the correct value because it's trying to fetch `committed_stock` which doesn't exists in the JSON response.