### PR TITLE
Add weight unit and value, set weight to read-only

### DIFF
--- a/lib/gecko/record/variant.rb
+++ b/lib/gecko/record/variant.rb
@@ -35,7 +35,9 @@ module Gecko
       attribute :opt2,            String
       attribute :opt3,            String
 
-      attribute :weight,          String
+      attribute :weight,          String,   readonly: true
+      attribute :weight_unit,     String
+      attribute :weight_value,    BigDecimal
 
       attribute :status,          String,   readonly: true
 


### PR DESCRIPTION
What are your thoughts on tests? I have VCR updating with data from my own TradeGecko. Should I generalize the data and submitted my own updated VCR file? As of now these fields are not tested so they should still pass.