### PR TITLE
Allow filtering `Adapter#count`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.1 (Unreleased)
+- Allow passing query parameters to `Adapter#count`
+
 ## 0.1.0 (2015-11-25)
 - Move default headers to the adapter base class to make it easier to merge them when overriding
 - Clean up old attributes

--- a/lib/gecko/record/base_adapter.rb
+++ b/lib/gecko/record/base_adapter.rb
@@ -120,11 +120,13 @@ module Gecko
       # @example
       #   client.Product.count
       #
+      # @param [#to_hash] params
+      #
       # @return [Integer] Total number of available records
       #
       # @api public
-      def count
-        self.where(limit: 0)
+      def count(params = {})
+        self.where(params.merge(limit: 0))
         @pagination['total_records']
       end
 


### PR DESCRIPTION
Currently you need to do the following to retrieve a filtered count
```ruby
client.Order.where(updated_at_min: 1.day.ago)
client.Order.size
```

This becomes
```ruby
client.Order.count(updated_at_min: 1.day.ago)
```