### PR TITLE
Faraday defaults to form-urlencoded which strips empty arrays from the payload as it builds a URL instead of sending JSON.

### DIFF
--- a/lib/gecko/record/base_adapter.rb
+++ b/lib/gecko/record/base_adapter.rb
@@ -412,6 +412,8 @@ module Gecko
           payload[:body]         = options[:body]
           payload[:model_class]  = model_class
           payload[:request_path] = path
+          options[:headers]      = options.fetch(:headers, {}).tap { |headers| headers['Content-Type'] = 'application/json' }
+          options[:body]         = options[:body].to_json if options[:body]
           payload[:response]     = @client.access_token.request(verb, path, options)
         end
       end

--- a/test/support/shared_adapter_examples.rb
+++ b/test/support/shared_adapter_examples.rb
@@ -150,7 +150,7 @@ private
     mock_token = mock
     mock_response = mock(status: response[0], parsed: response[1])
     mock_token.expects(:request)
-              .with(request[0], request[1], body: record.as_json, raise_errors: false)
+              .with(request[0], request[1], body: record.as_json.to_json, raise_errors: false, headers: {'Content-Type' => 'application/json'})
               .returns(mock_response)
     adapter.client.access_token = mock_token
   end


### PR DESCRIPTION
This PR should change our payload from form-urlencoded to json format (which our API requires).

The benefit of this is that the serialization of JSON will include an empty array, where form-urlencoded will strip it out.