### PR TITLE
Allow to update variant composite parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you are unfamiliar with the TradeGecko API, you can read the documentation lo
 
 Add this line to your application's Gemfile:
 
-    gem 'gecko-ruby', '~> 0.0.9'
+    gem 'gecko-ruby', '~> 0.1.1'
 
 And then execute:
 

--- a/lib/gecko/record/variant.rb
+++ b/lib/gecko/record/variant.rb
@@ -21,6 +21,13 @@ module Gecko
         attribute :value,            BigDecimal
       end
 
+      class CompositePart
+        include Virtus.model
+        include Gecko::Helpers::SerializationHelper
+        attribute :variant_id,        String
+        attribute :quantity,          BigDecimal
+      end
+
       belongs_to :product, writeable_on: :create
       has_many :images
 
@@ -70,6 +77,7 @@ module Gecko
       attribute :variant_prices,  Array[VariantPrice]
 
       attribute :composite,           Boolean,    writeable_on: :create
+      attribute :composite_parts,     Array[CompositePart],  writeable_on: :update
       attribute :initial_stock_level, BigDecimal, writeable_on: :create
       attribute :initial_cost_price,  BigDecimal, writeable_on: :create
 

--- a/lib/gecko/version.rb
+++ b/lib/gecko/version.rb
@@ -1,3 +1,3 @@
 module Gecko
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
With this we can update the composite parts of a variant. Example:
```ruby
variant = client.Variant.find(1)
variant.composite_parts = [{ variant_id: "2", quantity: 1 }, { variant_id: "3", quantity: 4 }]
variant.save
```