### PR TITLE
Add in support for Idempotency Keys

### DIFF
--- a/lib/gecko/record/base.rb
+++ b/lib/gecko/record/base.rb
@@ -43,11 +43,14 @@ module Gecko
 
       # Save a record
       #
+      # @param [Hash] opts the options to save the record with
+      # @option opts [Hash] :idempotency_key A unique identifier for this action
+      #
       # @return <Gecko::Record::Base>
       #
       # @api public
-      def save
-        @client.adapter_for(self.class.demodulized_name).save(self)
+      def save(opts = {})
+        @client.adapter_for(self.class.demodulized_name).save(self, opts)
       end
 
       # Return the demodulized class name

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -13,7 +13,7 @@ class ClientTest < Minitest::Test
   def test_custom_user_agent
     client  = Gecko::Client.new("ABC", "DEF")
     agent   = client.oauth_client.connection.headers["User-Agent"]
-    assert_match(%r|Gecko/#{Gecko::VERSION} OAuth2/\d.\d.\d Faraday/\d.\d.\d Ruby/\d.\d.\d|, agent)
+    assert_match(%r|Gecko/#{Gecko::VERSION} OAuth2/\d\.\d\.\d Faraday/\d\.\d+\.\d Ruby/\d\.\d\.\d|, agent)
   end
 
   def test_allows_test_URLs

--- a/test/record/account_adapter_test.rb
+++ b/test/record/account_adapter_test.rb
@@ -10,6 +10,7 @@ class Gecko::Record::AccountAdapterTest < Minitest::Test
   undef :test_build_with_attributes
   undef :test_saving_new_record
   undef :test_saving_new_invalid_record
+  undef :test_saving_record_with_idempotency_key
 
   let(:adapter)       { @client.Account }
   let(:plural_name)   { 'accounts' }

--- a/test/record/user_adapter_test.rb
+++ b/test/record/user_adapter_test.rb
@@ -17,6 +17,7 @@ class Gecko::Record::UserAdapterTest < Minitest::Test
   undef :test_build_with_attributes
   undef :test_saving_new_record
   undef :test_saving_new_invalid_record
+  undef :test_saving_record_with_idempotency_key
 
   def test_current
     VCR.use_cassette('users#current') do

--- a/test/support/shared_record_examples.rb
+++ b/test/support/shared_record_examples.rb
@@ -11,7 +11,7 @@ module SharedRecordExamples
   end
 
   def test_saving
-    @client.adapter_for(record_class.demodulized_name).expects(:save).with(@record)
+    @client.adapter_for(record_class.demodulized_name).expects(:save).with(@record, {})
     @record.save
   end
 


### PR DESCRIPTION
Over the next few weeks we're rolling out idempotency key support to the TG API.
This brings that functionality into the gem (completely opt-in for now)

```ruby
variant = client.Variant.build(product_id: 1, sku: ‘ABC’)
variant.save(idempotency_key: ‘my-idempotency-key’)
```