### PR TITLE
[FEATURE] Add support for embedded serialization of records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.5.0 (Unreleased)
+- [BREAKING CHANGE] has_many associations now return an enumerable
+  `CollectionProxy` where they used to return a plain array.
+- `has_many` associations now support `.build` which automatically assigns the parent
+  relation. `item = order.order_line_items.build(quantity: 123, variant_id: 123, price: 123)`
+  `item.order == order`.
+- Support for embedded serialization.
+  i.e `order.order_line_items.build(quantity: 123, price: 123, variant_id: 123); order.save`
+  will now save the Order and the order line items in a single API request.
+
 ## 0.2.5 (2018-01-15)
 - Add `User#account_name`
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ client.Product.where(ids: [123, 124])
 
 ## Building Records
 
+You can create new records by calling `build` on the appropriate adapter.
+
 ```ruby
 geckobot = client.Product.build(name: "Geckobot", product_type: "Robot")
 #=> <Gecko::Record::Product id=nil name="Geckobot" product_type: "Robot">
@@ -87,6 +89,8 @@ geckobot.persisted?
 
 #### Create Record
 
+You can persist new records by calling `save`.
+
 ```ruby
 geckobot = client.Product.build(name: "Geckobot", product_type: "Robot")
 #=> <Gecko::Record::Product id=nil name="Geckobot" product_type: "Robot">
@@ -96,6 +100,19 @@ geckobot.save # Persists to API
 #=> true
 geckobot
 #=> <Gecko::Record::Product id=124 name="Geckobot" product_type: "Robot">
+```
+
+You can also create new records from inside a parent object.
+
+```ruby
+variant = product.variants.build(name: "Geckobot", sku: "ROBO")
+#=> <Gecko::Record::Variant id=nil product_id=123 name="Geckobot" sku: "ROBO">
+variant.persisted?
+#=> false
+variant.save #=> Persists to API
+#=> true
+variant
+#=> <Gecko::Record::Variant id=125 product_id=123 name="Geckobot" sku: "ROBO">
 ```
 
 #### Update Record
@@ -111,6 +128,39 @@ geckobot.save # Persists to API
 geckobot
 #=> <Gecko::Record::Product id=124 name="Geckobot" product_type: "Robo-boogie">
 ```
+
+#### Embedded Record Serialization
+
+Some records support being saved inside of their parents.
+A good example is creating a Sales Order and it's line items.
+
+```ruby
+order = client.Order.build(company_id: 123, shipping_address_id: 123)
+order.order_line_items.build(quantity: 1, variant_id: 123, price: 10.5)
+order.order_line_items.build(quantity: 2, variant_id: 124, price: 11.0)
+order.save # Persists to API
+#=> true
+order.order_line_items
+#=> [<Gecko::Record::OrderLineItem id=125 variant_id=123 quantity: 1 price: '10.5'>,
+     <Gecko::Record::OrderLineItem id=126 variant_id=124 quantity: 2 price: '11.0'>]
+```
+
+This also works when adding new items to an existing order.
+
+```ruby
+order = client.Order.find(123)
+order.order_line_items.build(quantity: 1, variant_id: 123, price: 10.5)
+order.order_line_items.build(quantity: 2, variant_id: 124, price: 11.0)
+order.save # Persists to API
+#=> true
+order.order_line_items
+#=> [<Gecko::Record::OrderLineItem id=125 variant_id=123 quantity: 1 price: '10.5'>,
+     <Gecko::Record::OrderLineItem id=126 variant_id=124 quantity: 2 price: '11.0'>]
+```
+
+N.B. Only creation of embedded objects works at this time.
+Updating/Deleting embedded items must still be done by calling `save/destroy`
+on each of the child objects themselves.
 
 #### Validations
 

--- a/lib/gecko/helpers/association_helper.rb
+++ b/lib/gecko/helpers/association_helper.rb
@@ -115,7 +115,7 @@ module Gecko
       include Enumerable
       delegate :each, :empty?, to: :@target
 
-      attr_reader :association_name
+      attr_reader :association_name, :parent
 
       # Setup the child collection proxy
       #

--- a/lib/gecko/helpers/serialization_helper.rb
+++ b/lib/gecko/helpers/serialization_helper.rb
@@ -122,7 +122,11 @@ module Gecko
         new_records = collection_proxy.reject(&:persisted?)
         return unless new_records.any?
 
-        serialized[collection_proxy.association_name] = new_records.map(&:serializable_hash)
+        parent_key = collection_proxy.parent.class.demodulized_name.foreign_key.to_sym
+
+        serialized[collection_proxy.association_name] = new_records.map do |record|
+          record.serializable_hash.except(parent_key)
+        end
       end
     end
   end

--- a/lib/gecko/record/fulfillment.rb
+++ b/lib/gecko/record/fulfillment.rb
@@ -9,7 +9,7 @@ module Gecko
       belongs_to :billing_address,  class_name: 'Address'
       belongs_to :stock_location,  class_name: 'Location'
 
-      has_many :fulfillment_line_items
+      has_many :fulfillment_line_items, embedded: true
 
       attribute :status,           String
       attribute :exchange_rate,    String

--- a/lib/gecko/record/invoice.rb
+++ b/lib/gecko/record/invoice.rb
@@ -8,7 +8,7 @@ module Gecko
       belongs_to :billing_address
       belongs_to :payment_term
 
-      has_many :invoice_line_items
+      has_many :invoice_line_items, embedded: true
 
       attribute :invoice_number,  String
       attribute :invoiced_at,     Date

--- a/lib/gecko/record/order.rb
+++ b/lib/gecko/record/order.rb
@@ -5,7 +5,7 @@ module Gecko
     class Order < Base
       has_many :fulfillments
       has_many :invoices
-      has_many :order_line_items
+      has_many :order_line_items, embedded: true
 
       belongs_to :company
       belongs_to :contact

--- a/lib/gecko/record/order_line_item.rb
+++ b/lib/gecko/record/order_line_item.rb
@@ -24,9 +24,6 @@ module Gecko
       attribute :position,  Integer
 
       attribute :image_url, String,     readonly: true
-
-      # DEPRECATED
-      attribute :tax_rate,  BigDecimal
     end
 
     class OrderLineItemAdapter < BaseAdapter

--- a/test/helpers/association_helper_test.rb
+++ b/test/helpers/association_helper_test.rb
@@ -33,7 +33,7 @@ class Gecko::Helpers::AssociationHelperTest < Minitest::Test
   def test_has_many_without_ids
     record = @klass.new(@client, {order_ids: []})
     @client.Order.expects(:find_many).never
-    assert_equal([], record.orders)
+    assert_empty(record.orders)
   end
 
   def test_belongs_to
@@ -52,5 +52,28 @@ class Gecko::Helpers::AssociationHelperTest < Minitest::Test
     record = @klass.new(@client, {small_order_id: 56})
     @client.Order.expects(:find).with(56)
     record.small_order
+  end
+
+  def test_building_a_new_embedded_item
+    record = @client.Order.build({})
+    embedded = record.order_line_items.build(quantity: 1, variant_id: 1)
+    assert_instance_of(Gecko::Record::OrderLineItem, embedded)
+    assert_nil(embedded.order_id)
+    assert_instance_of(Gecko::Record::OrderLineItem, embedded)
+    assert(!embedded.persisted?)
+    assert_includes(record.order_line_items, embedded)
+    skip("This hasn't been implemented for fresh records yet")
+    assert_equal(record, embedded.order)
+  end
+
+  def test_building_a_new_embedded_item_on_existing_record
+    record = @client.Order.instantiate_and_register_record(id: 123)
+    embedded = record.order_line_items.build(quantity: 1, variant_id: 1)
+    assert_instance_of(Gecko::Record::OrderLineItem, embedded)
+    assert_equal(123, embedded.order_id)
+    assert_instance_of(Gecko::Record::OrderLineItem, embedded)
+    assert(!embedded.persisted?)
+    assert_includes(record.order_line_items, embedded)
+    assert_equal(record, embedded.order)
   end
 end

--- a/test/helpers/serialization_helper_test.rb
+++ b/test/helpers/serialization_helper_test.rb
@@ -80,6 +80,21 @@ class Gecko::Helpers::SerializationHelperTest < Minitest::Test
     assert_equal(:order_line_item, record.root)
   end
 
+  def test_serializing_new_embedded_items
+    record = Gecko::Record::Order.new(@client, {})
+    record.order_line_items.build(quantity: 1, variant_id: 1)
+    serialized = record.serializable_hash
+    assert(1, serialized[:order_line_items].length)
+    assert_equal(1, serialized[:order_line_items][0][:variant_id])
+    assert_equal('1.0', serialized[:order_line_items][0][:quantity])
+  end
+
+  def test_doesnt_add_embedded_keys_unless_required
+    record = Gecko::Record::Order.new(@client, {})
+    serialized = record.serializable_hash
+    assert(!serialized.key?(:order_line_items))
+  end
+
 private
 
   def serialized_record

--- a/test/helpers/serialization_helper_test.rb
+++ b/test/helpers/serialization_helper_test.rb
@@ -87,6 +87,7 @@ class Gecko::Helpers::SerializationHelperTest < Minitest::Test
     assert(1, serialized[:order_line_items].length)
     assert_equal(1, serialized[:order_line_items][0][:variant_id])
     assert_equal('1.0', serialized[:order_line_items][0][:quantity])
+    assert(!serialized[:order_line_items][0].key?(:order_id))
   end
 
   def test_doesnt_add_embedded_keys_unless_required

--- a/test/support/shared_sideloaded_data_parsing_examples.rb
+++ b/test/support/shared_sideloaded_data_parsing_examples.rb
@@ -8,7 +8,7 @@ module SharedSideloadedDataParsingExamples
         child_adapter = @client.adapter_for(child.singularize.classify)
 
         identity_map = child_adapter.instance_variable_get(:@identity_map)
-        child_collection = collection.flat_map { |record| record.send(child) }
+        child_collection = collection.flat_map { |record| record.send(child).to_a }
 
         assert_equal child_collection, identity_map.values
       end


### PR DESCRIPTION
This PR refactors how the `has_many` logic works to return a Proxy object instead of a plain Array.
With this extra piece we can now provide better creation of relations and also start serializing embedded items.

```ruby
order = client.Order.build(company_id: 123, shipping_address_id: 123)
order.order_line_items.build(quantity: 1, variant_id: 123, price: 10.5)
order.order_line_items.build(quantity: 2, variant_id: 124, price: 11.0)
order.save # Persists to API
#=> true
order.order_line_items
#=> [<Gecko::Record::OrderLineItem id=125 variant_id=123 quantity: 1 price: '10.5'>,
     <Gecko::Record::OrderLineItem id=126 variant_id=124 quantity: 2 price: '11.0'>]
```


Currently this adds support for embedded serialization for OrderLineItems (I'm still not sure if `embedded: true` on the model is the correct API/location, but gives an idea.

What doesn't it do:
- Only supports `OrderLineItem`s inside of `Order`s so far (it's just a simple toggle) **EDIT:** Now supports `FulfillmentLineItem` & `InvoiceLineItem` as well
- Doesn't provide embedded `update`/`destroy` semantics, (we don't currently have dirty tracking or deletion supported even non-embedded)
- Purposefully doesn't support `client.Order.create(order_line_items: [{qty: 1}])`
- Doesn't support embedding `belongs_to` relations (will be another spike)