### PR TITLE
[ENHANCEMENT] Add actions

### DIFF
--- a/lib/gecko/helpers/action_helper.rb
+++ b/lib/gecko/helpers/action_helper.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Gecko
+  module Helpers
+    # Helper for actions
+    module ActionHelper
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        # Creates an action that allows a record class to perform that specific action.
+        #
+        # @example
+        #   class Gecko::Record::Order
+        #     action :invoice
+        #   end
+        #
+        # @param [Symbol] action
+        #
+        # @return [Boolean]
+        #
+        # @api public
+        def action(action_name)
+          define_method action_name do
+            name = self.class.demodulized_name
+            @client.adapter_for(name).action(self, action_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gecko/helpers/validation_helper.rb
+++ b/lib/gecko/helpers/validation_helper.rb
@@ -87,5 +87,9 @@ module Gecko
         @messages[attr.to_sym] = errors
       end
     end
+
+    def from_action(action_name, errors)
+      @messages[action_name] = errors
+    end
   end
 end

--- a/lib/gecko/record/base.rb
+++ b/lib/gecko/record/base.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+require 'gecko/helpers/action_helper'
 require 'gecko/helpers/association_helper'
 require 'gecko/helpers/inspection_helper'
 require 'gecko/helpers/serialization_helper'
@@ -7,7 +10,8 @@ module Gecko
   module Record
     class Base
       include Virtus.model
-      include  Gecko::Helpers::AssociationHelper
+      include Gecko::Helpers::ActionHelper
+      include Gecko::Helpers::AssociationHelper
       include Gecko::Helpers::InspectionHelper
       include Gecko::Helpers::SerializationHelper
       include Gecko::Helpers::ValidationHelper

--- a/lib/gecko/record/order.rb
+++ b/lib/gecko/record/order.rb
@@ -50,6 +50,11 @@ module Gecko
       # attribute :source,                String
 
       # attribute :invoice_numbers,       Hash[Integer => String], readonly: true
+
+      action :invoice
+      action :pay
+      action :pack
+      action :fulfil
     end
 
     class OrderAdapter < BaseAdapter

--- a/test/helpers/action_helper_test.rb
+++ b/test/helpers/action_helper_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'gecko'
+
+class Gecko::Helpers::ActionHelperTest < Minitest::Test
+  def setup
+    @klass = Class.new(Gecko::Record::Base) do
+      action :fire
+    end
+    @client = Gecko::Client.new('ABC', 'DEF')
+  end
+
+  def test_adds_action_methods
+    record = @klass.new(@client, {})
+    assert(record.respond_to?(:fire))
+  end
+end

--- a/test/helpers/validation_helper_test.rb
+++ b/test/helpers/validation_helper_test.rb
@@ -21,4 +21,11 @@ class Gecko::Helpers::ValidationHelperTest < Minitest::Test
     assert(!record.valid?)
     assert_equal(record.errors[:name], ["is not shiny"])
   end
+
+  def test_from_action
+    record = @klass.new(@client, name: "Gecko")
+    record.errors.from_action(:pay, "Can't pay")
+    assert(!record.valid?)
+    assert_equal(record.errors[:pay], "Can't pay")
+  end
 end

--- a/test/record/account_adapter_test.rb
+++ b/test/record/account_adapter_test.rb
@@ -11,6 +11,7 @@ class Gecko::Record::AccountAdapterTest < Minitest::Test
   undef :test_saving_new_record
   undef :test_saving_new_invalid_record
   undef :test_saving_record_with_idempotency_key
+  undef :test_action_error
 
   let(:adapter)       { @client.Account }
   let(:plural_name)   { 'accounts' }

--- a/test/record/user_adapter_test.rb
+++ b/test/record/user_adapter_test.rb
@@ -18,6 +18,7 @@ class Gecko::Record::UserAdapterTest < Minitest::Test
   undef :test_saving_new_record
   undef :test_saving_new_invalid_record
   undef :test_saving_record_with_idempotency_key
+  undef :test_action_error
 
   def test_current
     VCR.use_cassette('users#current') do


### PR DESCRIPTION
This PR creates an `action` keyword for resources.

- [x] Success handling: Return true.
  - We cannot just update the entity map, because some endpoints for actions do not return the original `Record` that was requested (for example, `orders/[:id]/actions/invoice` returns an array of invoices, without the original order sideloaded). We know that `invoice_status` has been updated, but there are other fields that might have been updated as well. The work-around for now is to return `true` if the request was successful, and return `false` if it wasn't.
- [x] Error handling: Returns `false` and updates the `Record`'s `errors` hash to include the name of the action.
- [x] Tests. I am still learning minitest and how the testing convention looks like for the gem 😄, so feel free to add comments
- [ ] Actions for the other endpoints. Planning to add these endpoints after this PR has been accepted.
- [ ] Hound. I can look into this later, in another PR, though the fastest solution would be to just copy our other repos' `rubocop.yml` as a baseline.