### PR TITLE
Add basic LogSubscriber and LiquidCompat modules to gem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+## 0.9.0 (Unreleased)
+- Added an optional `ActiveSupport::LogSubscriber` class for easy logging,
+  can be enabled via `Gecko.enable_logging`.
+- Added an optional compatibility shim for the Liquid templating language, 
+  can be enabled via `Gecko.install_liquid_shim`.
+
 ## 0.8.0 (2019-07-01)
-- Add `discount_amount` attribute and `discounted_price` helper to `OrderLineItem`'s
-- Drop support for Ruby 2.3
+- Add `discount_amount` attribute and `discounted_price` helper to `OrderLineItem`'s.
+- Drop support for EOL Ruby 2.3 as well.
 
 ## 0.7.1 (2019-03-19)
 - Add `Gecko::Record::Note` model.
@@ -8,7 +14,7 @@
 
 ## 0.7.0 (2019-02-19)
 - Add new `country_code` attribute to Address model.
-- Stop testing on Ruby 2.1 and 2.2
+- Stop testing on Ruby 2.1 and 2.2.
 
 ## 0.6.0 (2018-11-13)
 - Add `Gecko::Record::Webhook` model.
@@ -26,51 +32,51 @@
 - Add minimum `oauth2` gem dependency
 
 ## 0.2.5 (2018-01-15)
-- Add `User#account_name`
+- Add `User#account_name`.
 
 ## 0.2.4 (2017-08-28)
-- Add `Company#tags`
+- Add `Company#tags`.
 
 ## 0.2.3 (2017-08-14)
-- Add support for API idempotency `@client.Record.save(idempotency_key: 'ABCDEF123456')`
-- Marked a couple of fields as readonly that weren't correctly marked so
+- Add support for API idempotency `@client.Record.save(idempotency_key: 'ABCDEF123456')`.
+- Marked a couple of fields as readonly that weren't correctly marked so.
 
 ## 0.2.2 (2016-06-06)
-- Add `@client.Record.peek_all` to return all items currently in identity map
+- Add `@client.Record.peek_all` to return all items currently in identity map.
 
 ## 0.2.1 (2016-06-06) (Yanked)
 ## 0.2.0 (2016-06-06)
-- Support `writeable_on :create` for attributes
-- Allow passing query parameters to `Adapter#count`
-- Add `@client.Record.first` and `@client.Record.forty_two` as helpers
-- Store the last API response at `@client.Record.last_response`
-- Make sure to set Content-Type to `application/json`
-- Clean up some deprecated fields leading up to API release (See [https://developer.tradegecko.com](https://developer.tradegecko.com) for up-to-date attribute list)
+- Support `writeable_on :create` for attributes.
+- Allow passing query parameters to `Adapter#count`.
+- Add `@client.Record.first` and `@client.Record.forty_two` as helpers.
+- Store the last API response at `@client.Record.last_response`.
+- Make sure to set Content-Type to `application/json`.
+- Clean up some deprecated fields leading up to API release (See [https://developer.tradegecko.com](https://developer.tradegecko.com) for up-to-date attribute list).
 
 ## 0.1.0 (2015-11-25)
-- Move default headers to the adapter base class to make it easier to merge them when overriding
-- Clean up old attributes
+- Move default headers to the adapter base class to make it easier to merge them when overriding.
+- Clean up old attributes.
 
 ## 0.0.10 (2015-10-21)
-- Add `first_name`/`last_name` to addresses
+- Add `first_name`/`last_name` to addresses.
 
 ## 0.0.9 (2015-10-02)
-- Add tags to order
+- Add tags to order.
 
 ## 0.0.8 (2015-09-10)
-- Fetch `VariantLocation#committed_stock` as committed
-- Make image uploading work
+- Fetch `VariantLocation#committed_stock` as committed.
+- Make image uploading work.
 
 ## 0.0.7 (2015-03-17)
-- Fix issue with `Order#tax_override`
-- Support sideloaded records without a hack
+- Fix issue with `Order#tax_override`.
+- Support sideloaded records without a hack.
 
 ## 0.0.6 (2015-03-17)
-- Add `Gecko::Record::PaymentTerm`
+- Add `Gecko::Record::PaymentTerm`.
 
 ## 0.0.5 (2015-03-04)
-- Add size to base adapter
-- Update serialization_helper to support serializing arrays correctly
+- Add `size` to base adapter.
+- Update serialization_helper to support serializing arrays correctly.
 
 ## 0.0.4 (2015-01-09)
 - Renamed gem so we can publish it on RubyGems.org

--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ ActiveSupport::Notifications.subscribe('request.gecko') do |name, start, finish,
 end
 ```
 
+The gem comes with a default `LogSubscriber` that outputs API requests in an ActiveRecord style.
+This is disabled by default and can be included by calling `Gecko.enable_logging`.
+
 ## Checking API limits
 
 The Gecko gem stores a copy of the last API response per adapter.
@@ -203,6 +206,10 @@ client.Product.last_response.headers['X-Rate-Limit-Remaining']
 client.Product.last_response.headers['X-Rate-Limit-Reset']
 #=> '1412079600'
 ```
+
+## Liquid Compatibility
+A compatibility shim for the Liquid templating language is distributed, but not loaded by default.
+This can be enabled via `Gecko.install_liquid_shim`
 
 ## TODO
 - Deleting records

--- a/lib/gecko.rb
+++ b/lib/gecko.rb
@@ -32,3 +32,13 @@ require 'gecko/record/purchase_order_line_item'
 require 'gecko/record/tax_type'
 require 'gecko/record/payment_term'
 require 'gecko/record/webhook'
+
+module Gecko
+  def self.enable_logging
+    require 'gecko/ext/log_subscriber'
+  end
+
+  def self.install_liquid_shim
+    require 'gecko/ext/liquid_compat'
+  end
+end

--- a/lib/gecko/ext/liquid_compat.rb
+++ b/lib/gecko/ext/liquid_compat.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Including this file enhances every Gecko::Record object to support the Liquid::Drop API.
+#
+# @example
+#   template = Liquid::Template.parse("{{variant.sku}}")
+#   rendered = template.render('variant' => client.Variant.find(123))
+module Gecko
+  # Monkey-patches the base record class with a `to_liquid` method
+  module LiquidCompatibility
+    # The Liquid templating library automatically uses a `to_liquid` method if found.
+    def to_liquid
+      liquid_decorator.new(self)
+    end
+
+  private
+
+    # If you'd like to add custom behviour per-record-type,
+    # override this method and return a subclass.
+    #
+    # @example
+    #
+    #   module MyLiquidCompat
+    #     def liquid_decorator
+    #       "#{self.class.demodulized_name}Decorator".safe_constantize || BaseDecorator
+    #     end
+    #   end
+    #
+    #   Gecko::Record::Base.include(MyLiquidCompat)
+    def liquid_decorator
+      Gecko::BaseDecorator
+    end
+  end
+
+  Gecko::Record::Base.include(LiquidCompatibility)
+  Gecko::Helpers::CollectionProxy.delegate(:to_liquid, to: :@target)
+
+  class BaseDecorator < Liquid::Drop
+    def initialize(delegate)
+      raise 'Turtles all the way down' if delegate.is_a?(BaseDecorator)
+
+      @delegate = delegate
+    end
+
+    def method_missing(method_name, *args, &block)
+      if @delegate.respond_to?(method_name)
+        @delegate.public_send(method_name, *args, &block)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      @delegate.respond_to?(method_name) || super
+    end
+
+    ## Override Liquid::Drop#invoke_drop to also check method arity
+    def invoke_drop(method_or_key)
+      if self.invokable_methods.include?(method_or_key.to_s) && self.method_arity(method_or_key.to_sym) <= 0
+        self.public_send(method_or_key)
+      end
+    end
+
+    ## Override Liquid::Drop#invokable_methods to add extra checks
+    def invokable_methods
+      @invokable_methods ||= begin
+        blacklist = Gecko::Record::Base.public_instance_methods + Liquid::Drop.public_instance_methods
+        blacklist -= [:to_liquid, :id, :created_at, :updated_at]
+        whitelist = self.public_methods + @delegate.public_methods
+        available_methods = (whitelist - blacklist).map(&:to_s)
+        available_methods.reject! { |method_name| method_name.ends_with?("=") }
+        Set.new(available_methods)
+      end
+    end
+
+  protected
+
+    def method_arity(method_name)
+      if self.methods.include?(method_name)
+        self.method(method_name).arity
+      else
+        @delegate.method(method_name).arity
+      end
+    end
+
+    def client
+      @delegate.instance_variable_get(:@client)
+    end
+  end
+end

--- a/lib/gecko/ext/log_subscriber.rb
+++ b/lib/gecko/ext/log_subscriber.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'request_store'
+
+# Requiring this file, or calling `Gecko.enable_logging` will hook into the provided
+# ActiveSupport::Notification hooks on requests and log ActiveRecord-style messages
+# on API requests.
+class GeckoLogSubscriber < ActiveSupport::LogSubscriber
+  ENV_KEY = :"gecko-logger"
+
+  def initialize
+    super
+    @odd = false
+  end
+
+  def request(event)
+    RequestStore.store[ENV_KEY] = []
+    payload = event.payload
+
+    request_path = payload[:request_path]
+
+    if payload[:params] && payload[:verb] == :get
+      request_path = request_path + "?" + payload[:params].to_param
+      RequestStore.store[ENV_KEY] << request_path
+    end
+
+    name  = "#{payload[:model_class]} Load (#{event.duration.round(1)}ms)"
+    query = "#{payload[:verb].to_s.upcase} /#{request_path}"
+
+    if odd?
+      name = color(name, CYAN, true)
+    else
+      name = color(name, MAGENTA, true)
+    end
+
+    query = color(query, nil, true)
+
+    debug("  #{name}  #{query}")
+  end
+
+  def odd?
+    @odd = !@odd
+  end
+end
+
+GeckoLogSubscriber.attach_to :gecko


### PR DESCRIPTION
These are included in the distributed gem, but not required by default.

