### PR TITLE
Fix Variant serialization

### DIFF
--- a/lib/gecko/helpers/serialization_helper.rb
+++ b/lib/gecko/helpers/serialization_helper.rb
@@ -110,6 +110,8 @@ module Gecko
       #
       # @api private
       def embedded_collections_for_serialization
+        return [] unless respond_to?(:collection_proxies, true)
+
         collection_proxies.values.select(&:embed_records?)
       end
 

--- a/test/record/variant_test.rb
+++ b/test/record/variant_test.rb
@@ -43,4 +43,19 @@ class Gecko::VariantTest < Minitest::Test
     assert_equal(0,        locations[0].committed_stock)
     assert_equal("AB-123", locations[0].bin_location)
   end
+
+  def test_serialization
+    json = {
+      locations: [
+        { location_id: 1, stock_on_hand: "12.50", committed: "0", bin_location: "AB-123", available: true },
+      ],
+      variant_prices: [
+        { price_list_id: "buy", value: "12.50"}, {price_list_id: 123, value: "14.00" }
+      ]
+    }
+
+    variant = record_class.new(client, json)
+
+    assert_instance_of(Hash, variant.as_json)
+  end
 end


### PR DESCRIPTION
Hi,

The problem: I got `NameError (undefined local variable or method 'collection_proxies' for #<Gecko::Record::Variant::VariantLocation:0x00007ff8f67d2d40>)` when tried to update a Variant. Reproduction steps are easy, just call `as_json` on any variant.

Looks like `collection_proxies` is defined in `AssociationHelper`: 
https://github.com/tradegecko/gecko/blob/7629e0226e94af2cf055f335d68c086acfa61062/lib/gecko/helpers/association_helper.rb#L91-L93

And is referenced inside `SerializationHelper`: https://github.com/tradegecko/gecko/blob/7629e0226e94af2cf055f335d68c086acfa61062/lib/gecko/helpers/serialization_helper.rb#L112-L114

`VariantPrice`/`VariantLocation` do not include the `AssociationHelper`, hence the exception: https://github.com/tradegecko/gecko/blob/7629e0226e94af2cf055f335d68c086acfa61062/lib/gecko/record/variant.rb#L19-L24

Possible solutions: either include `AssociationHelper` in `VariantPrice` and `VariantLocation` or check if the record responds to `collection_proxies` before serializing it. I went with the check.