### PR TITLE
Switch authorize url to new domain

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Run Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Change authorize url to commerce.intuit.com
+
 ## 0.12.1 (2020-07-20)
 - Add `Gecko::Record::PaymentMethod` model.
 

--- a/lib/gecko/client.rb
+++ b/lib/gecko/client.rb
@@ -127,7 +127,7 @@ module Gecko
     def setup_oauth_client(client_id, client_secret, options)
       defaults = {
         site:            'https://api.tradegecko.com',
-        authorize_url:   'https://go.tradegecko.com/oauth/authorize',
+        authorize_url:   'https://commerce.intuit.com/oauth/authorize',
         connection_opts: {
           headers: self.class.default_headers
         }


### PR DESCRIPTION
#### Summary
Authorize url should use new domain `commerce.intuit.com`
 
Motivation: https://jira.intuit.com/browse/QBCO-1453